### PR TITLE
Use an explicit relative import to avoid accidentally importing from st2common.runners.base_action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,8 @@
 
 ## v0.1.1
 
-Version bump to fix tagging issues. No code changes
+- Version bump to fix tagging issues. No code changes
 
 ## v0.1.0
 
-Initial Revision
+- Initial Revision

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v0.1.2
+
+- Use explicit relative imports to avoid accidentally importing from
+  st2common.runners.base_action (bugfix) [PR #5]
+
 ## v0.1.1
 
 - Version bump to fix tagging issues. No code changes

--- a/actions/lib/ping.py
+++ b/actions/lib/ping.py
@@ -1,4 +1,4 @@
-from base_action import BaseAction
+from .base_action import BaseAction
 
 
 class PingAction(BaseAction):

--- a/actions/lib/query.py
+++ b/actions/lib/query.py
@@ -1,4 +1,4 @@
-from base_action import BaseAction
+from .base_action import BaseAction
 
 
 class QueryAction(BaseAction):

--- a/actions/lib/write.py
+++ b/actions/lib/write.py
@@ -1,4 +1,4 @@
-from base_action import BaseAction
+from .base_action import BaseAction
 
 
 class WriteAction(BaseAction):

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - influx
   - database
   - timeseries
-version: 0.1.1
+version: 0.1.2
 author: Encore Technologies
 email: code@encore.tech
 python_versions:


### PR DESCRIPTION
This small tweak ensures that we are importing from the pack's `actions/lib` directory instead of StackStorm's `st2common.runners.base_action` module.